### PR TITLE
Update config.yaml: waive test for instana-agent-operator-rhmp

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,9 @@ tests:
       - ^falcon-operator-rhmp
       - ^instana-agent-operator-rhmp
       - ^sumologic-kubernetes-collection-helm-operator-rhmp
+  - name: check_bundle_higher_than_channel_head
+    ignore_operators:
+      - ^instana-agent-operator-rhmp
 
 index_image:
   repository: quay.io/redhat/redhat----redhat-marketplace-index


### PR DESCRIPTION
Add waiver of check_bundle_higher_than_channel_head test for instana-agent-operator because the test can't tell that "instana-agent-operator-rhmp/2.2.13" is actually greater than "instana-agent-operator-rhmp/v2.0.30.